### PR TITLE
small edits

### DIFF
--- a/docs/about/about.md
+++ b/docs/about/about.md
@@ -8,7 +8,9 @@ iTELL is an open source framework for developing and deploying intelligent textb
 
 ### Comprehension checks
 
-Embed summary tasks and short answer tests into your textbook to ensure that students understand the contents of the textbook. Automate the whole process and reduce teacher workload: an AI model will automatically create short answer questions, evaluate student responses (both summaries and short answers), and provide appropriate feedback to students.
+Automate the whole process and reduce teacher workload: AI models will automatically create short answer questions, evaluate student responses, and provide appropriate feedback.
+
+iTELL automatically generates summary tasks and short answer questions tailored to your source material. Student responses are evaluated using state-of-the-art systems, ensuring that students understand the content they are reading. Students receive targeted, immediate feedback to help them efficiently address gaps in their understanding.
 
 ### Teacher dashboard
 
@@ -30,5 +32,4 @@ Visit the [AI-ALOE website](https://aialoe.org/) or the [LEAR lab website](https
 
 ## Contact us
 
-iTELL is looking for teachers interested in bringing this interactive textbook framework into their classroom. Contact us at itell@itell.com to discuss potentialy uses.
-
+iTELL is motivated to work with teachers and organizations who are aligned with our mission of making instructional materials more interactive. Contact us at lear.lab.vu@gmail.com to start a discussion.

--- a/docs/data/focus.md
+++ b/docs/data/focus.md
@@ -1,6 +1,6 @@
 # Focus Time
 
-Focus time (the duration where something is visible in a user's viewport) is tracked on a per-section-element basis. When the user enters a section, the visible time of every text paragraph, figure and video elements get is recorded. The css selector used is
+Focus time (the duration where something is visible in a user's viewport) is tracked on a per-section-element basis. When the user enters a section, the visible time of every text paragraph, figure and video elements get is recorded. The CSS selector used is
 
 ```javascript
 content.querySelectorAll("h1, h2, p, img, video, iframe")

--- a/docs/data/identity.md
+++ b/docs/data/identity.md
@@ -1,12 +1,12 @@
 # Identity Management
 
-When a user first logs in he/she is required to input some identity data. Currently we only support logins via one's google account. Other methods will be added later, e.g., email-password, phone number or via other social providers.
+When a user first logs in, they are required to input some identity data. Currently we only support logins via Google account. We are working on additional authentication options: email/password, SSO with Learning Management Systems.
 
 ## Sample data
 
-User data is stored in two places, firebase's built-in user pool and firestore.
+User data is stored in two places, FireBase's built-in user pool and FireStore.
 
-The user pool stores what is returned from the identity provider. For example, a user created via google login has
+The user pool stores what is returned from the identity provider. For example, a user created via Google login has
 
 ```json
 {
@@ -38,7 +38,7 @@ The user pool stores what is returned from the identity provider. For example, a
 }
 ```
 
-Firestore stores business-relevant user data.
+FireStore keeps a record of user data.
 
 ```json
 {

--- a/docs/data/index.md
+++ b/docs/data/index.md
@@ -1,3 +1,9 @@
 # Data Collection
 
-We collect data.
+iTELL is designed for use by academic researchers who are interested in measuring and improving student learning outcomes. By default, iTELL collects data on the following:
+- User Sessions
+- Written responses to short answer questions and summaries and scores associated with these responses
+- Keystroke records (only keys presses entered into an iTELL text box)
+- Clickstream data (scrolling, navigation, etc. -- only within the iTELL web app)
+
+The data that iTELL collects is stored on a secure database. When data is exported from iTELL for research purposes, all personally identifiable information is removed.

--- a/docs/development/content.md
+++ b/docs/development/content.md
@@ -1,6 +1,7 @@
 # Restructuring your Textbook for iTELL
 
 ## Modules, Chapters, Sections, and Subsections
+
 ```
 └── Content/
     └── Section/
@@ -17,17 +18,20 @@
         ├── Module 2
         └── ...
 ```
-iTELL expects text contents to be provided using three separate levels: `Modules`, `Chapters`, `Sections`, and `Subsections`. `Modules` are collections of `Chapters`, and `Chapters` collections of `Sections`. Each `Module` and `Chapter` are represented as subdirectories in the `content` folder. Each `Section` will live inside a corresponding `Chapter` directory as an `.mdx` file, and `Subsections` as components within the `Section` file.
+
+iTELL expects text content to be provided using three separate levels: `Modules` (optional), `Chapters`, `Sections`, and `Subsections`. `Modules` are collections of `Chapters`, and `Chapters` collections of `Sections`. Each `Module` and `Chapter` are represented as subdirectories in the `content` folder. Each `Section` is located within a `Chapter` directory as a `.md` or `.mdx` file. `Subsections` are an organizational unit used by iTELL to divide up long sections. In a `Section` Markdown file, iTELL uses Markdown Level-1 and Level-2 headings to divide the text into meaningful units. `Subsections` work best when they are 200-400 words long (about 3 paragraphs). 
 
 iTELL is in the process of developing a feature that will facilitate the restructuring of any textbook into these levels. Currently, the recommendation is that individual content developers restructure their textbook to these four levels using their own discretion and custom scripts.
 
+## Content Authoring
 
-## MDX and JSX/TSX
-After you divide your textbook contents into `Sections` and transfer them into individual MDX files, the contents then have to be reformatted following MDX syntax. You can use regular Markdown syntax and custom JSX/TSX components to increase your textbook's interactivity.
+After you divide your textbook contents into `Sections` and create the appropriate file structure for your textbook, the contents then have to be formatted in Markdown. You can use regular Markdown (`.md`), which is a simple and intuitive language for text formatting. If you want to customize the content and appearance further, you can also include Javascript in your Markdown files (`.mdx`). We have created some predefined JavaScript components to increase your textbook's interactivity.
 
-### MD
+### Markdown
+
 #### Frontmatter
-Data about the `Section` should be included at the top of each MDX file between sets of three hyphens (---).
+
+Each `Section` file should include a title card at the top, between two sets of three hyphens (---). This provides information about the `Section` page.
 ```
 ---
 title: "What Is Economics And Why Is It Important?"
@@ -35,41 +39,25 @@ title: "What Is Economics And Why Is It Important?"
 ```
 
 #### Headings
-Headings are created with consecutive hash characters (#).
+Headings are created with consecutive hash characters (#). iTELL uses Level-1 and Level-2 headings to divide the text into subsections. iTELL AI tools will ignore Level-3 and lower headings, but they can still be used to visually organize the text.
+```
 ```
 # H1
 ## H2
 ### H3
 ...
-
+```
 ```
 
-#### Lists
-Unordered lists are created with asterisks and ordered lists with numbers followed by a period.
-```
-* unordered list item 1
-* unordered list item 2
+#### General Markdown Formatting
+For Markdown formatting options that are not specific to iTELL, please refer to the following excellent guides: [Markdown Guide](https://www.markdownguide.org/basic-syntax/) and [Chicago Docs](https://kabartolo.github.io/chicago-docs-demo/docs/mdx-guide/writing/).
 
-1. ordered list item 1
-2. ordered list item 2
-...
-```
-
-#### Links
-Links are created by enclosing the link texts in square brackets and the URL in parantheses.
-```
-[Link text](https://www.yoururl.com)
-```
-
-#### Others
-There are multiple great resources you can use as a reference when writing Markdown. Here is one by [Markdown Guide](https://www.markdownguide.org/basic-syntax/) and one by [Chicago Docs](https://kabartolo.github.io/chicago-docs-demo/docs/mdx-guide/writing/)
-
-
-### JSX/TSX
-MDX supports the use of custom JSX/TSX components. Below are some custom components that come prebuilt with iTELL.
+### Javascript
+iTELL supports supports the use of custom Javascript components in MDX (`.mdx`) files. Below are some custom components that come prebuilt with iTELL.
 
 #### Info and Callout
 ![info](images/component_info_callout.png)
+
 ##### Info
 ```
 <Info title="Title for info card">
@@ -85,6 +73,7 @@ MDX supports the use of custom JSX/TSX components. Below are some custom compone
 
 #### Columns, Image, and YoutubeVideo
 ![info](images/component_columns_image_youtubevideo.png)
+
 ##### Columns
 ```
 <Columns>
@@ -97,6 +86,7 @@ MDX supports the use of custom JSX/TSX components. Below are some custom compone
   ...
 </Columns>
 ```
+
 ##### Image
 ```
 <Image
@@ -155,7 +145,4 @@ MDX supports the use of custom JSX/TSX components. Below are some custom compone
 ```
 
 ## Further customization
-Refer to `packages/ui/src/components/callout.tsx` to find other custom components provided by iTELL. Also note that iTELL is completely open source and you can write your own components for further customization.
-
-
-
+Refer to `packages/ui/src/components/callout.tsx` to find other custom components provided by iTELL. You can also use these as a reference for creating your own components!

--- a/docs/development/dependency.md
+++ b/docs/development/dependency.md
@@ -8,36 +8,21 @@ iTELL requires the following applications and databases to be set up to function
 + Backend - scoring engine and API (FastAPI): <https://github.com/learlab/textbook-summary-api>
 + Database (Postgres)
 
-Follow the steps below to deploy your own intelligent textbook.
-
+In this tutorial, we will show you how to set up iTELL using some popular hosting services that have generous free tiers. You can also use your own hosting services of choice.
 
 ## Step 1. Set up a Postgres database
 
-Set up a Postgres database of your choice. The default iTELL application uses [Supabase](https://supabase.com/). Migration will be handled by [Prisma](https://www.prisma.io/) as part of Step 3. All required files for the migration are included in [the prisma folder in the frontend application's Github repository](https://github.com/learlab/itell/tree/main/apps/example-poe/prisma).
-
+The default iTELL application uses [Supabase](https://supabase.com/). Migration will be handled by [Prisma](https://www.prisma.io/) as part of Step 3. All required files for the migration are included in [the prisma folder in the frontend application's Github repository](https://github.com/learlab/itell/tree/main/apps/example-poe/prisma).
 
 ## Step 2. Set up the Backend
-The backend was developed using Python's [FastAPI](https://fastapi.tiangolo.com/). You can use different setups and cloud services for local development and deployment.
 
-### Local development
-Clone [the backend github repository](https://github.com/learlab/textbook-summary-api) and 1) install the requirements from the pipfile and 2) download the required models from SpaCy and Huggingface for use in a local environment:
+iTELL uses an AI-powered scoring API to evaluate student writing. It was developed using Python's [FastAPI](https://fastapi.tiangolo.com/). You can use different setups and cloud services for local development and deployment, such as Google Cloud Run or Heroku. The API is packaged as a Docker container, so deployment is as easy as creating a `.env` file with information about your SupaBase database and deploying to a hosting service.
 
-```
-git clone https://github.com/learlab/textbook-summary-api)
-cd textbook-summary-api
-pip install -r requirements.txt
-python .\download_models.py
-```
+Documentation for the API is located at [the backend github repository](https://github.com/learlab/textbook-summary-api).
 
-### Deployment
-You can deploy the application using any web hosting service of your preference. A Dockerfile is included in the repository for use. Note that a server with a GPU is required to run the summary and QA evaluation models at a practical speed. After deployment, test whether the GPU is enabled by using the `/gpu` endpoint.
+## Step 3. Deploy iTELL to Vercel
 
-You can read more about the development and deployment from the repo's `read.me` [file](https://github.com/learlab/textbook-summary-api/blob/main/README.md).
-
-
-## Step 3. Frontend deployment
-
-Use a web hosting provider of your choice to deploy the frontend. The default iTELL application uses [Vercel](https://vercel.com/). We will first go over the general setup requirements, and then we will provide a short example of what the deployment will look like when using Vercel.
+The default iTELL application uses [Vercel](https://vercel.com/). We will first go over the general setup requirements, and then we will provide a short example of what the deployment will look like when using Vercel.
 
 ### Environment variables
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # iTELL
 
-This website holds documentation for the deployment and customization fo iTELL, an intelligent textbook framework developed by [AI-ALOE](https://aialoe.org/) and [LEAR lab](https://learlab.org/).
+This is the documentation website for iTELL, an intelligent textbook framework developed by [AI-ALOE](https://aialoe.org/) and [LEAR lab](https://learlab.org/).
 
 - [What is iTELL](./about/about.md)
 - [Development](./development/dependency.md)


### PR DESCRIPTION
- fixed some formatting / capitalization
- altered some wording
- Drafted a data collection section
- Made the deployment guide more focused on Vercel/Supabase
- Emphasized that iTELL will work with plain Markdown (JS optional)
- Deleted basic markdown formatting info. Better to link to someone else who has done a more thorough job.
- Deleted detailed info on scoring-api and backend. Better to link to the repository (this way, we don't need to udpate two different guides when something changes).